### PR TITLE
Add onclick handler from mod info

### DIFF
--- a/block_course_modulenavigation.php
+++ b/block_course_modulenavigation.php
@@ -342,8 +342,10 @@ class block_course_modulenavigation extends block_base {
                             ['context' => $context]
                     );
                     $thismod->url = $module->url;
+                    $thismod->onclick = $module->onclick;
                     if ($module->modname == 'label') {
                         $thismod->url = '';
+                        $thismod->onclick = '';
                         $thismod->label = 'true';
                     }
                     $hascompletion = $completioninfo->is_enabled($module);

--- a/templates/coursenav.mustache
+++ b/templates/coursenav.mustache
@@ -46,6 +46,7 @@
                             {
                                 "name":"Test",
                                 "url":{},
+                                "onclick":{},
                                 "completeclass":"incomplete"
                             }
                         ],
@@ -94,7 +95,7 @@
                         {{#modules}}
                             {{^onlytitles}}
                                 <li>
-                                    <a href="{{{url}}}" class="{{active}} {{#label}}modulenavigationlabel{{/label}}">
+                                    <a href="{{{url}}}" class="{{active}} {{#label}}modulenavigationlabel{{/label}}" onclick="{{{onclick}}}">
                                         {{#completionon}}
                                             <div class="completionbox">
                                                 <div class="completioncheck {{completeclass}}">


### PR DESCRIPTION
Course modules create an onclick handler to go along with their URL so that activities like file/scorm can open new windows/tabs etc.
Look at resource_get_coursemodule_info in mod/resource/lib.php for an example.
This change brings that into this plugin.